### PR TITLE
Implement #49 getRelativeRotationTo method in Coordinates

### DIFF
--- a/Common/src/main/java/com/github/sef24sp4/common/data/Coordinates.java
+++ b/Common/src/main/java/com/github/sef24sp4/common/data/Coordinates.java
@@ -1,6 +1,11 @@
 package com.github.sef24sp4.common.data;
 
-public class Coordinates {
+import com.github.sef24sp4.common.interfaces.IVector;
+
+import java.util.Objects;
+
+public class Coordinates implements IVector {
+	private static final IVector UNIT_VECTOR = new Coordinates(1, 0);
 	private double x;
 	private double y;
 
@@ -21,16 +26,50 @@ public class Coordinates {
 		this.y = y;
 	}
 
+	@Override
 	public double getX() {
 		return this.x;
 	}
 
+	@Override
 	public double getY() {
 		return this.y;
 	}
 
 
-	public double getRelativeRotationTo(Coordinates otherCoordinates) {
-		throw new UnsupportedOperationException("Not yet implemented");
+	/**
+	 * Get a vector between current coordinates and the passed in coordinates.
+	 *
+	 * @param coordinates The other coordinates. Maybe any type of vector.
+	 * @return A vector between the two coordinates.
+	 */
+	public IVector getVectorTo(IVector coordinates) {
+		double deltaX = coordinates.getX() - this.getX();
+		double deltaY = coordinates.getY() - this.getY();
+		return new Coordinates(deltaX, deltaY);
+	}
+
+
+	/**
+	 * Get the relative rotation to the passed in coordinates.
+	 *
+	 * @param coordinates The coordinates to get relative rotation to.
+	 * @return The relative rotation in radians.
+	 */
+	public double getRelativeRotationTo(IVector coordinates) {
+		IVector vector = this.getVectorTo(coordinates);
+		return vector.getAngleBetween(Coordinates.UNIT_VECTOR);
+	}
+
+
+	@Override
+	public boolean equals(Object o) {
+		if (o instanceof Coordinates other) return this.getX() == other.getX() && this.getY() == other.getY();
+		return false;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(this.x, this.y);
 	}
 }

--- a/Common/src/main/java/com/github/sef24sp4/common/interfaces/IVector.java
+++ b/Common/src/main/java/com/github/sef24sp4/common/interfaces/IVector.java
@@ -1,0 +1,48 @@
+package com.github.sef24sp4.common.interfaces;
+
+public interface IVector {
+
+	/**
+	 * Get value of x.
+	 *
+	 * @return Value of x.
+	 */
+	public double getX();
+
+	/**
+	 * Get value of y.
+	 *
+	 * @return Value of y.
+	 */
+	public double getY();
+
+	/**
+	 * Calculate the norm e.i. the length of the current vector.
+	 *
+	 * @return The norm.
+	 */
+	public default double getNorm() {
+		System.out.println(this.getX());
+		return Math.sqrt(Math.pow(this.getX(), 2) + Math.pow(this.getY(), 2));
+	}
+
+	/**
+	 * Calculate the dot product between current vector and the passed in vector.
+	 *
+	 * @param otherVector The vector to calculate dot product with.
+	 * @return The resulting dot product.
+	 */
+	public default double getDotProduct(IVector otherVector) {
+		return this.getX() * otherVector.getX() + this.getY() * otherVector.getY();
+	}
+
+	/**
+	 * Calculates the angle between the current vector and the passed in vector.
+	 *
+	 * @param otherVector The vector to get the angle in between with.
+	 * @return The angle in radians.
+	 */
+	public default double getAngleBetween(IVector otherVector) {
+		return Math.acos(this.getDotProduct(otherVector) / (this.getNorm() * otherVector.getNorm()));
+	}
+}

--- a/Common/src/test/java/com/github/sef24sp4/common/data/CoordinatesTest.java
+++ b/Common/src/test/java/com/github/sef24sp4/common/data/CoordinatesTest.java
@@ -1,0 +1,56 @@
+package com.github.sef24sp4.common.data;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CoordinatesTest {
+
+	private Coordinates coordinates;
+	private Coordinates otherCoordinates;
+
+	@BeforeEach
+	void setUp() {
+		this.coordinates = new Coordinates(3, 4);
+		this.otherCoordinates = new Coordinates(5, 8);
+	}
+
+	@AfterEach
+	void tearDown() {
+	}
+
+	@Test
+	void setX() {
+		assertDoesNotThrow(() -> this.coordinates.setX(42));
+		assertEquals(42, this.coordinates.getX());
+	}
+
+	@Test
+	void setY() {
+		assertDoesNotThrow(() -> this.coordinates.setY(42));
+		assertEquals(42, this.coordinates.getY());
+	}
+
+	@Test
+	void getVectorTo() {
+		assertEquals(new Coordinates(2, 4), this.coordinates.getVectorTo(this.otherCoordinates));
+	}
+
+	@Test
+	void getRelativeRotationTo() {
+		assertEquals(1.1071487177940904, this.coordinates.getRelativeRotationTo(this.otherCoordinates));
+	}
+
+	@Test
+	void testEquals() {
+		assertEquals(new Coordinates(3, 4), this.coordinates);
+	}
+
+	@Test
+	void testHashCode() {
+		assertEquals(new Coordinates(3, 4).hashCode(), this.coordinates.hashCode());
+	}
+}

--- a/Common/src/test/java/com/github/sef24sp4/common/interfaces/IVectorTest.java
+++ b/Common/src/test/java/com/github/sef24sp4/common/interfaces/IVectorTest.java
@@ -1,0 +1,64 @@
+package com.github.sef24sp4.common.interfaces;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class IVectorTest {
+
+	private IVector vector;
+	private IVector otherVector;
+
+	@BeforeEach
+	void setUp() {
+		this.vector = new IVector() {
+			@Override
+			public double getX() {
+				return 3;
+			}
+
+			@Override
+			public double getY() {
+				return 4;
+			}
+		};
+
+		this.otherVector = new IVector() {
+			@Override
+			public double getX() {
+				return 5;
+			}
+
+			@Override
+			public double getY() {
+				return 3;
+			}
+		};
+	}
+
+	@Test
+	void getX() {
+		assertEquals(3, this.vector.getX());
+	}
+
+	@Test
+	void getY() {
+		assertEquals(4, this.vector.getY());
+	}
+
+	@Test
+	void getNorm() {
+		assertEquals(5, this.vector.getNorm());
+	}
+
+	@Test
+	void getDotProduct() {
+		assertEquals(27, this.vector.getDotProduct(this.otherVector));
+	}
+
+	@Test
+	void getAngleBetween() {
+		assertEquals(0.386875717731028, this.vector.getAngleBetween(this.otherVector));
+	}
+}


### PR DESCRIPTION
Closes #49
I have additionally created a `IVector` interface to abstract some of the vector specific elements away from `Coordinates` class. 
If any one disagrees with this distinction please say so. 