### PR TITLE
Make IEntityManager.removeEntity return boolean

### DIFF
--- a/Common/src/main/java/com/github/sef24sp4/common/interfaces/IEntityManager.java
+++ b/Common/src/main/java/com/github/sef24sp4/common/interfaces/IEntityManager.java
@@ -7,9 +7,9 @@ import java.util.List;
 
 public interface IEntityManager {
 
-	public void addEntity(IEntity entity);
+	public boolean addEntity(IEntity entity);
 
-	public IEntity removeEntity(IEntity entity);
+	public boolean removeEntity(IEntity entity);
 
 	public List<IEntity> getAllEntities();
 


### PR DESCRIPTION
This is more inline with how the List interface is defined. Furthermore returning the entity which was passed in as parameter is useless. There can at least be of some use to know whether or not the operation was successful.