### PR TITLE
Make IMouseCoordinates extend the IVector interface

### DIFF
--- a/Common/src/main/java/com/github/sef24sp4/common/gamecontrol/IMouseCoordinates.java
+++ b/Common/src/main/java/com/github/sef24sp4/common/gamecontrol/IMouseCoordinates.java
@@ -1,16 +1,6 @@
 package com.github.sef24sp4.common.gamecontrol;
 
-import com.github.sef24sp4.common.data.Coordinates;
+import com.github.sef24sp4.common.interfaces.IVector;
 
-public interface IMouseCoordinates {
-	public Coordinates getCoordinates();
-
-	public default double getX() {
-		return this.getCoordinates().getX();
-	}
-
-	public default double getY() {
-		return this.getCoordinates().getY();
-	}
-
+public interface IMouseCoordinates extends IVector {
 }


### PR DESCRIPTION
This gives much greater flexibility when implementing the IMouseCoordinates. It also simplifies interactions with IMouseCoordinates, and they conform to a shared interface IVector.