### PR TITLE
Improve syntax for setPolygonCoordinates and memory optimisations for CommonEntity

### DIFF
--- a/Common/src/main/java/com/github/sef24sp4/common/entities/CommonEntity.java
+++ b/Common/src/main/java/com/github/sef24sp4/common/entities/CommonEntity.java
@@ -2,6 +2,7 @@ package com.github.sef24sp4.common.entities;
 
 import com.github.sef24sp4.common.data.Coordinates;
 
+import java.util.Arrays;
 import java.util.List;
 
 public class CommonEntity implements IEntity {
@@ -35,6 +36,10 @@ public class CommonEntity implements IEntity {
 
 	public void setPolygonCoordinates(List<Coordinates> polygonCoordinates) {
 		this.polygonCoordinates = polygonCoordinates;
+	}
+
+	public void setPolygonCoordinates(Coordinates... polygonCoordinates) {
+		this.setPolygonCoordinates(Arrays.asList(polygonCoordinates));
 	}
 
 	@Override

--- a/Common/src/main/java/com/github/sef24sp4/common/entities/CommonEntity.java
+++ b/Common/src/main/java/com/github/sef24sp4/common/entities/CommonEntity.java
@@ -19,17 +19,13 @@ public class CommonEntity implements IEntity {
 		this.getCoordinates().setY(y);
 	}
 
-	public void setCoordinates(Coordinates coordinates) {
-		this.coordinates = coordinates;
-	}
-
 	@Override
 	public Coordinates getCoordinates() {
 		return this.coordinates;
 	}
 
-	public void setPolygonCoordinates(List<Coordinates> polygonCoordinates) {
-		this.polygonCoordinates = polygonCoordinates;
+	public void setCoordinates(Coordinates coordinates) {
+		this.coordinates = coordinates;
 	}
 
 	@Override
@@ -37,12 +33,16 @@ public class CommonEntity implements IEntity {
 		return this.polygonCoordinates;
 	}
 
-	public void setRotation(double rotation) {
-		this.rotation = rotation;
+	public void setPolygonCoordinates(List<Coordinates> polygonCoordinates) {
+		this.polygonCoordinates = polygonCoordinates;
 	}
 
 	@Override
 	public double getRotation() {
 		return this.rotation;
+	}
+
+	public void setRotation(double rotation) {
+		this.rotation = rotation;
 	}
 }

--- a/Common/src/main/java/com/github/sef24sp4/common/entities/CommonEntity.java
+++ b/Common/src/main/java/com/github/sef24sp4/common/entities/CommonEntity.java
@@ -2,15 +2,18 @@ package com.github.sef24sp4.common.entities;
 
 import com.github.sef24sp4.common.data.Coordinates;
 
-import java.util.Arrays;
 import java.util.List;
 
 public class CommonEntity implements IEntity {
 	private Coordinates coordinates;
 
-	private List<Coordinates> polygonCoordinates;
+	private Coordinates[] polygonCoordinates;
 
 	private double rotation;
+
+	public CommonEntity() {
+		this.coordinates = new Coordinates();
+	}
 
 	public void setX(double x) {
 		this.getCoordinates().setX(x);
@@ -30,16 +33,16 @@ public class CommonEntity implements IEntity {
 	}
 
 	@Override
-	public List<Coordinates> getPolygonCoordinates() {
+	public Coordinates[] getPolygonCoordinates() {
 		return this.polygonCoordinates;
 	}
 
 	public void setPolygonCoordinates(List<Coordinates> polygonCoordinates) {
-		this.polygonCoordinates = polygonCoordinates;
+		this.polygonCoordinates = polygonCoordinates.toArray(new Coordinates[0]);
 	}
 
 	public void setPolygonCoordinates(Coordinates... polygonCoordinates) {
-		this.setPolygonCoordinates(Arrays.asList(polygonCoordinates));
+		this.polygonCoordinates = polygonCoordinates;
 	}
 
 	@Override

--- a/Common/src/main/java/com/github/sef24sp4/common/entities/IEntity.java
+++ b/Common/src/main/java/com/github/sef24sp4/common/entities/IEntity.java
@@ -2,11 +2,22 @@ package com.github.sef24sp4.common.entities;
 
 import com.github.sef24sp4.common.data.Coordinates;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public interface IEntity {
 
 	public List<Coordinates> getPolygonCoordinates();
+
+	public default double[] getPolygonValuesArray() {
+		List<Double> output = new ArrayList<>(this.getPolygonCoordinates().size() * 2);
+		this.getPolygonCoordinates().forEach(coordinates -> {
+			output.add(coordinates.getX());
+			output.add(coordinates.getY());
+		});
+		// See: https://stackoverflow.com/a/23945015
+		return output.stream().mapToDouble(Double::doubleValue).toArray();
+	}
 
 	public double getRotation();
 

--- a/Common/src/main/java/com/github/sef24sp4/common/entities/IEntity.java
+++ b/Common/src/main/java/com/github/sef24sp4/common/entities/IEntity.java
@@ -7,14 +7,14 @@ import java.util.List;
 
 public interface IEntity {
 
-	public List<Coordinates> getPolygonCoordinates();
+	public Coordinates[] getPolygonCoordinates();
 
 	public default double[] getPolygonValuesArray() {
-		List<Double> output = new ArrayList<>(this.getPolygonCoordinates().size() * 2);
-		this.getPolygonCoordinates().forEach(coordinates -> {
+		List<Double> output = new ArrayList<>(this.getPolygonCoordinates().length * 2);
+		for (Coordinates coordinates : this.getPolygonCoordinates()) {
 			output.add(coordinates.getX());
 			output.add(coordinates.getY());
-		});
+		}
 		// See: https://stackoverflow.com/a/23945015
 		return output.stream().mapToDouble(Double::doubleValue).toArray();
 	}

--- a/Common/src/test/java/com/github/sef24sp4/common/entities/CommonEntityTest.java
+++ b/Common/src/test/java/com/github/sef24sp4/common/entities/CommonEntityTest.java
@@ -1,0 +1,85 @@
+package com.github.sef24sp4.common.entities;
+
+import com.github.sef24sp4.common.data.Coordinates;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CommonEntityTest {
+	private CommonEntity entity;
+
+	@BeforeEach
+	void setUp() {
+		this.entity = new CommonEntity();
+	}
+
+	@Test
+	void setX() {
+		this.entity.setX(20);
+		assertEquals(20, this.entity.getCoordinates().getX());
+	}
+
+	@Test
+	void setY() {
+		this.entity.setY(20);
+		assertEquals(20, this.entity.getCoordinates().getY());
+	}
+
+	@Test
+	void getCoordinates() {
+		this.entity.setX(30);
+		this.entity.setY(42);
+		assertEquals(new Coordinates(30, 42), this.entity.getCoordinates());
+	}
+
+	@Test
+	void setPolygonCoordinates() {
+		final Coordinates c1 = new Coordinates(3, 4);
+		final Coordinates c2 = new Coordinates(2, -7);
+		List<Coordinates> testCoordinates = new ArrayList<>();
+		testCoordinates.add(c1);
+		testCoordinates.add(c2);
+
+		final Coordinates[] actualCoordinates = new Coordinates[]{c1, c2};
+		this.entity.setPolygonCoordinates(testCoordinates);
+		assertArrayEquals(actualCoordinates, this.entity.getPolygonCoordinates());
+	}
+
+	@Test
+	void setPolygonCoordinatesVarargs() {
+		final Coordinates c1 = new Coordinates(3, 4);
+		final Coordinates c2 = new Coordinates(2, -7);
+		this.entity.setPolygonCoordinates(
+				c1,
+				c2
+		);
+		final Coordinates[] actualCoordinates = new Coordinates[]{c1, c2};
+		assertArrayEquals(actualCoordinates, this.entity.getPolygonCoordinates());
+	}
+
+
+	@Test
+	void getPolygonValuesArray() {
+		final Coordinates c1 = new Coordinates(3, 4);
+		final Coordinates c2 = new Coordinates(2, -7);
+		this.entity.setPolygonCoordinates(
+				c1,
+				c2
+		);
+		final double[] actualCoordinates = new double[]{c1.getX(), c1.getY(), c2.getX(), c2.getY()};
+
+		assertArrayEquals(actualCoordinates, this.entity.getPolygonValuesArray());
+	}
+
+	@Test
+	void getRotation() {
+		this.entity.setRotation(234);
+		assertEquals(234, this.entity.getRotation());
+	}
+
+}


### PR DESCRIPTION
# What has changed?
## Add overloaded method `setPolygonCoordinates(Coordinates... polygonCoordinates)`
This improves syntax for adding polygon coordinates. 
It is now possible to write:
```java
entity.setPolygonCoordinates(
		new Coordinates(2, 2),
		new Coordinates(2, -2),
		new Coordinates(-2, -2),
		new Coordinates(-2, 2)
);
```
I think this syntax is quite simple and prettier than: 
```java
List<Coordinates> polygonCoordinates = new ArrayList<>();
polygonCoordinates.add(new Coordinates(2, 2));
polygonCoordinates.add(new Coordinates(2, -2));
polygonCoordinates.add(new Coordinates(-2, -2));
polygonCoordinates.add(new Coordinates(-2, 2));
entity.setPolygonCoordinates(polygonCoordinates);
```
> [!NOTE]
> The this syntax is still valid. 
> And can be used in conjunction with the new syntax. 

## Changed underlying storage of polygonCoordinates to native arrays.
This improves memory usage, as native arrays (`Coordinates[]`) uses less memory than `ArrayList<Coordinates>`. 
This is significant when many entities are added. 

## Added unit tests
Have added units tests. This allowed be me to discover a bug in our code, where coordinates are not initialised when `CommonEntity` is constructed. 