### PR TITLE
Common/metadata/61 fix get type return null

### DIFF
--- a/Common/src/main/java/com/github/sef24sp4/common/metadata/GameMetadata.java
+++ b/Common/src/main/java/com/github/sef24sp4/common/metadata/GameMetadata.java
@@ -2,6 +2,7 @@ package com.github.sef24sp4.common.metadata;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 public class GameMetadata implements IGameMetadata {
 	private final Map<String, String> map;
@@ -17,8 +18,8 @@ public class GameMetadata implements IGameMetadata {
 	}
 
 	@Override
-	public String getProperty(String identifier) {
-		return this.map.get(identifier);
+	public Optional<String> getProperty(String identifier) {
+		return Optional.ofNullable(this.map.get(identifier));
 	}
 
 	@Override

--- a/Common/src/main/java/com/github/sef24sp4/common/metadata/GameMetadata.java
+++ b/Common/src/main/java/com/github/sef24sp4/common/metadata/GameMetadata.java
@@ -4,12 +4,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class GameMetadata implements IGameMetadata {
-	private GameElementType type;
-
-	private Map<String, String> map;
+	private final Map<String, String> map;
+	private final GameElementType type;
 
 	GameMetadata(GameElementType type) {
-		this.setType(type);
+		this.type = type;
 		this.map = new HashMap<>();
 	}
 
@@ -22,13 +21,8 @@ public class GameMetadata implements IGameMetadata {
 		return this.map.get(identifier);
 	}
 
-
-	void setType(GameElementType type) {
-		this.type = type;
-	}
-
 	@Override
 	public GameElementType getType() {
-		return null;
+		return this.type;
 	}
 }

--- a/Common/src/main/java/com/github/sef24sp4/common/metadata/IGameMetadata.java
+++ b/Common/src/main/java/com/github/sef24sp4/common/metadata/IGameMetadata.java
@@ -1,7 +1,9 @@
 package com.github.sef24sp4.common.metadata;
 
+import java.util.Optional;
+
 public interface IGameMetadata {
-	public String getProperty(String identifier);
+	public Optional<String> getProperty(String identifier);
 
 	public GameElementType getType();
 }

--- a/Common/src/main/java/com/github/sef24sp4/common/metadata/MetadataBuilder.java
+++ b/Common/src/main/java/com/github/sef24sp4/common/metadata/MetadataBuilder.java
@@ -1,7 +1,7 @@
 package com.github.sef24sp4.common.metadata;
 
 public class MetadataBuilder {
-	private GameMetadata metadata;
+	private final GameMetadata metadata;
 
 
 	public MetadataBuilder(GameElementType type) {

--- a/Common/src/test/java/com/github/sef24sp4/common/metadata/GameMetadataTest.java
+++ b/Common/src/test/java/com/github/sef24sp4/common/metadata/GameMetadataTest.java
@@ -1,0 +1,32 @@
+package com.github.sef24sp4.common.metadata;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class GameMetadataTest {
+	private GameMetadata metadata;
+
+	@BeforeEach
+	void setUp() {
+		this.metadata = new GameMetadata(GameElementType.ENEMY);
+	}
+
+	@Test
+	void nullProperty() {
+		assertNull(this.metadata.getProperty("test.not_a_key"));
+	}
+
+	@Test
+	void getProperty() {
+		this.metadata.setProperty("test", "hello world");
+		assertEquals("hello world", this.metadata.getProperty("test"));
+	}
+
+	@Test
+	void getType() {
+		assertEquals(GameElementType.ENEMY, this.metadata.getType());
+	}
+}

--- a/Common/src/test/java/com/github/sef24sp4/common/metadata/GameMetadataTest.java
+++ b/Common/src/test/java/com/github/sef24sp4/common/metadata/GameMetadataTest.java
@@ -3,8 +3,7 @@ package com.github.sef24sp4.common.metadata;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 class GameMetadataTest {
 	private GameMetadata metadata;
@@ -16,13 +15,15 @@ class GameMetadataTest {
 
 	@Test
 	void nullProperty() {
-		assertNull(this.metadata.getProperty("test.not_a_key"));
+		assertTrue(this.metadata.getProperty("test.not_a_key").isEmpty());
 	}
 
 	@Test
 	void getProperty() {
 		this.metadata.setProperty("test", "hello world");
-		assertEquals("hello world", this.metadata.getProperty("test"));
+		assertDoesNotThrow(() -> {
+			assertEquals("hello world", this.metadata.getProperty("test").get());
+		}, "Could not `get` value from returned property");
 	}
 
 	@Test

--- a/Common/src/test/java/com/github/sef24sp4/common/metadata/MetadataBuilderTest.java
+++ b/Common/src/test/java/com/github/sef24sp4/common/metadata/MetadataBuilderTest.java
@@ -1,0 +1,23 @@
+package com.github.sef24sp4.common.metadata;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MetadataBuilderTest {
+	private MetadataBuilder builder;
+
+	@BeforeEach
+	void setUp() {
+		this.builder = new MetadataBuilder(GameElementType.ITEM);
+	}
+
+	@Test
+	void getMetadata() {
+		this.builder.setProperty("test", "hello");
+		IGameMetadata metadata = this.builder.getMetadata();
+		assertEquals(GameElementType.ITEM, metadata.getType());
+		assertEquals("hello", metadata.getProperty("test"));
+	}
+}

--- a/Common/src/test/java/com/github/sef24sp4/common/metadata/MetadataBuilderTest.java
+++ b/Common/src/test/java/com/github/sef24sp4/common/metadata/MetadataBuilderTest.java
@@ -3,7 +3,7 @@ package com.github.sef24sp4.common.metadata;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 class MetadataBuilderTest {
 	private MetadataBuilder builder;
@@ -15,9 +15,13 @@ class MetadataBuilderTest {
 
 	@Test
 	void getMetadata() {
-		this.builder.setProperty("test", "hello");
+		assertInstanceOf(MetadataBuilder.class, this.builder.setProperty("test", "hello"));
 		IGameMetadata metadata = this.builder.getMetadata();
+
 		assertEquals(GameElementType.ITEM, metadata.getType());
-		assertEquals("hello", metadata.getProperty("test"));
+
+		assertDoesNotThrow(() -> {
+			assertEquals("hello", metadata.getProperty("test").get());
+		});
 	}
 }


### PR DESCRIPTION
# What has been done
## Fixes #61 

## Implements unit tests

## Made `IGameMetadata.getProperty()` return `Optional<String>`

The use of optional is to force checks for non null value.
The reason for this is that getProperty() method will return null when a key does not match. Optional forces you to check for `null` values to minimize potential null pointer exceptions and other common programming errors.
It also provides helper methods so it becomes easier to do different actions depending on if the value is null.

For instance check if value is not null: 
```java
if (metadata.getProperty("somekey").isPresent()) {
	System.out.println("There is a value!");
}
```

Or execute code only if value is present:

```java
metadata.getProperty("somekey").ifPresent(value -> {
	System.out.println("Found this value: " + value);
});
```

Or return default value if non is present:
```java
String value = metadata.getProperty("somekey").orElse("default value here");
```

Plus many more see: https://docs.oracle.com/javase/8/docs/api/java/util/Optional.html

