### PR TITLE
Make Coordinates Cloneable

### DIFF
--- a/Common/src/main/java/com/github/sef24sp4/common/data/Coordinates.java
+++ b/Common/src/main/java/com/github/sef24sp4/common/data/Coordinates.java
@@ -4,7 +4,7 @@ import com.github.sef24sp4.common.interfaces.IVector;
 
 import java.util.Objects;
 
-public class Coordinates implements IVector {
+public class Coordinates implements IVector, Cloneable {
 	private static final IVector UNIT_VECTOR = new Coordinates(1, 0);
 	private double x;
 	private double y;
@@ -70,5 +70,14 @@ public class Coordinates implements IVector {
 	@Override
 	public int hashCode() {
 		return Objects.hash(this.x, this.y);
+	}
+
+	@Override
+	public Coordinates clone() {
+		try {
+			return (Coordinates) super.clone();
+		} catch (CloneNotSupportedException e) {
+			throw new AssertionError("Clone operation failed for Class Coordinates");
+		}
 	}
 }

--- a/Common/src/test/java/com/github/sef24sp4/common/data/CoordinatesTest.java
+++ b/Common/src/test/java/com/github/sef24sp4/common/data/CoordinatesTest.java
@@ -4,8 +4,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 class CoordinatesTest {
 
@@ -52,5 +51,15 @@ class CoordinatesTest {
 	@Test
 	void testHashCode() {
 		assertEquals(new Coordinates(3, 4).hashCode(), this.coordinates.hashCode());
+	}
+
+	@Test
+	void testClone() {
+		final Coordinates clone = this.coordinates.clone();
+		assertNotSame(this.coordinates, clone);
+		clone.setX(23);
+		clone.setY(78);
+		assertNotEquals(this.coordinates.getX(), clone.getX());
+		assertNotEquals(this.coordinates.getY(), clone.getY());
 	}
 }


### PR DESCRIPTION
This makes it easier to get new coordinates based on existing coordinates.
This is useful for projectile creation and more.

Usage 
```java
Coordinates newCoordinates = entity.getCoordinates().clone();
```
