### PR TITLE
Common/entitymanager/78 prevent duplicate entities

### DIFF
--- a/Common/src/main/java/com/github/sef24sp4/common/data/EntityManager.java
+++ b/Common/src/main/java/com/github/sef24sp4/common/data/EntityManager.java
@@ -3,24 +3,25 @@ package com.github.sef24sp4.common.data;
 import com.github.sef24sp4.common.entities.IEntity;
 import com.github.sef24sp4.common.interfaces.IEntityManager;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
 
 public class EntityManager implements IEntityManager {
-	private final List<IEntity> entities = new ArrayList<>();
+	private final Collection<IEntity> entities = new HashSet<>();
 
 	@Override
-	public boolean addEntity(IEntity entity) {
+	public boolean addEntity(final IEntity entity) {
 		return this.entities.add(entity);
 	}
 
 	@Override
-	public boolean removeEntity(IEntity entity) {
+	public boolean removeEntity(final IEntity entity) {
 		return this.entities.remove(entity);
 	}
 
 	@Override
-	public List<IEntity> getAllEntities() {
-		return this.entities;
+	public Collection<IEntity> getAllEntities() {
+		return Collections.unmodifiableCollection(this.entities);
 	}
 }

--- a/Common/src/main/java/com/github/sef24sp4/common/interfaces/IEntityManager.java
+++ b/Common/src/main/java/com/github/sef24sp4/common/interfaces/IEntityManager.java
@@ -2,23 +2,55 @@ package com.github.sef24sp4.common.interfaces;
 
 import com.github.sef24sp4.common.entities.IEntity;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
 
+/**
+ * An EntityManager used to keep track of all active {@link IEntity entities} in the game.
+ */
 public interface IEntityManager {
 
-	public boolean addEntity(IEntity entity);
+	/**
+	 * Add {@link IEntity} to the EntityManager if not already present in the manager.
+	 * This means there may never be duplicate entities within the same manager.
+	 * Specifically that no two objects ({@code e}, {@code e2}) exists such that {@code e.equals(e2)} is {@code true}.
+	 *
+	 * @param entity The {@link IEntity entity} to be added.
+	 * @return {@code true} if manager did not already contain {@code entity}, and the {@code entity} was added successfully.
+	 * {@code false} if the manager already contained the {@code entity}.
+	 */
+	public boolean addEntity(final IEntity entity);
 
-	public boolean removeEntity(IEntity entity);
+	/**
+	 * Removes the {@code entity} from the manager if present, according to {@link Object#equals entity.equals()} method.
+	 *
+	 * @param entity The {@link IEntity entity} to be removed.
+	 * @return {@code true} if {@code entity} was present and successfully removed.
+	 * {@code false} if the manager did not contain the {@code entity}.
+	 */
+	public boolean removeEntity(final IEntity entity);
 
-	public List<IEntity> getAllEntities();
+	/**
+	 * Get a {@link Collections#unmodifiableCollection read-only Collection} with all entities contained within the manager.
+	 *
+	 * @return A {@link Collections#unmodifiableCollection read-only Collection} with the entities.
+	 */
+	public Collection<IEntity> getAllEntities();
 
-	public default <E extends IEntity> List<E> getEntitiesByClass(Class<E> entityType) {
-		List<E> output = new ArrayList<>();
+	/**
+	 * Get a {@link Collections#unmodifiableCollection read-only Collection} containing all entities from this manager of the {@code entityType}.
+	 *
+	 * @param entityType A {@link Class} for the type of entities to retrieve.
+	 * @param <E>        The entity type.
+	 * @return A {@link Collections#unmodifiableCollection read-only Collection} with the entities of {@code entityType}.
+	 */
+	public default <E extends IEntity> Collection<E> getEntitiesByClass(final Class<E> entityType) {
+		final Collection<E> output = new HashSet<>();
 		this.getAllEntities().forEach((entity) -> {
 			if (entityType.isInstance(entity)) output.add(entityType.cast(entity));
 		});
-		return output;
+		return Collections.unmodifiableCollection(output);
 	}
 
 	/**
@@ -26,10 +58,10 @@ public interface IEntityManager {
 	 *
 	 * @param entityType The type of entities to remove.
 	 * @param <E>        The entity type.
-	 * @return A {@link List} of the removed entities.
+	 * @return A {@link Collection} of the removed entities.
 	 */
-	public default <E extends IEntity> List<E> removeEntitiesByClass(Class<E> entityType) {
-		List<E> entities = this.getEntitiesByClass(entityType);
+	public default <E extends IEntity> Collection<E> removeEntitiesByClass(final Class<E> entityType) {
+		final Collection<E> entities = this.getEntitiesByClass(entityType);
 		entities.forEach(this::removeEntity);
 		return entities;
 	}

--- a/Common/src/test/java/com/github/sef24sp4/common/data/EntityManagerTest.java
+++ b/Common/src/test/java/com/github/sef24sp4/common/data/EntityManagerTest.java
@@ -1,0 +1,122 @@
+package com.github.sef24sp4.common.data;
+
+import com.github.sef24sp4.common.entities.CommonEntity;
+import com.github.sef24sp4.common.entities.IEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EntityManagerTest {
+
+	private EntityManager entityManager;
+
+	@BeforeEach
+	void setUp() {
+		this.entityManager = new EntityManager();
+	}
+
+	@Test
+	void addEntity() {
+		final IEntity entity = new CommonEntity();
+		assertTrue(this.entityManager.addEntity(entity));
+		assertFalse(this.entityManager.addEntity(entity));
+
+		assertEquals(1, this.entityManager.getAllEntities().size());
+
+		assertTrue(this.entityManager.getAllEntities().contains(entity));
+	}
+
+	@Test
+	void removeEntity() {
+		final IEntity entity1 = new CommonEntity();
+		final IEntity entity2 = new CommonEntity();
+
+		assertTrue(this.entityManager.addEntity(entity1));
+		assertTrue(this.entityManager.addEntity(entity2));
+		assertEquals(2, this.entityManager.getAllEntities().size());
+		assertTrue(this.entityManager.getAllEntities().contains(entity1));
+
+		assertTrue(this.entityManager.removeEntity(entity1));
+		assertEquals(1, this.entityManager.getAllEntities().size());
+		assertFalse(this.entityManager.getAllEntities().contains(entity1));
+
+		assertFalse(this.entityManager.removeEntity(entity1));
+
+		assertTrue(this.entityManager.getAllEntities().contains(entity2));
+	}
+
+	@Test
+	void getAllEntities() {
+		final IEntity entity = new CommonEntity();
+		assertTrue(this.entityManager.addEntity(entity));
+
+		final Collection<IEntity> collection = this.entityManager.getAllEntities();
+
+		assertTrue(collection.contains(entity));
+
+		assertThrows(UnsupportedOperationException.class, () -> {
+			collection.add(new CommonEntity());
+		});
+		assertThrows(UnsupportedOperationException.class, () -> {
+			collection.remove(entity);
+		});
+	}
+
+	@Test
+	void getEntitiesByClass() {
+		final IEntity entityA = new TestEntityA();
+		final IEntity entityB = new TestEntityB();
+
+		assertTrue(this.entityManager.addEntity(entityA));
+		assertTrue(this.entityManager.addEntity(entityB));
+
+		final Collection<CommonEntity> collection = this.entityManager.getEntitiesByClass(CommonEntity.class);
+
+		assertEquals(2, collection.size());
+		assertTrue(collection.contains(entityA));
+		assertTrue(collection.contains(entityB));
+
+		final Collection<TestEntityA> collectionA = this.entityManager.getEntitiesByClass(TestEntityA.class);
+		final Collection<TestEntityB> collectionB = this.entityManager.getEntitiesByClass(TestEntityB.class);
+
+		assertEquals(1, collectionA.size());
+		assertEquals(1, collectionB.size());
+
+		assertTrue(collectionA.contains(entityA));
+		assertTrue(collectionB.contains(entityB));
+
+		assertThrows(UnsupportedOperationException.class, () -> {
+			collectionA.remove(entityA);
+		});
+
+		assertThrows(UnsupportedOperationException.class, () -> {
+			collectionB.remove(entityB);
+		});
+	}
+
+	@Test
+	void removeEntitiesByClass() {
+		final IEntity entityA = new TestEntityA();
+		final IEntity entityB = new TestEntityB();
+
+		assertTrue(this.entityManager.addEntity(entityA));
+		assertTrue(this.entityManager.addEntity(entityB));
+
+		final Collection<TestEntityA> removedA = this.entityManager.removeEntitiesByClass(TestEntityA.class);
+
+		assertTrue(removedA.contains(entityA));
+		assertFalse(removedA.contains(entityB));
+
+		assertFalse(this.entityManager.getAllEntities().contains(entityA));
+		assertTrue(this.entityManager.getAllEntities().contains(entityB));
+	}
+
+	private static final class TestEntityA extends CommonEntity {
+	}
+
+	private static final class TestEntityB extends CommonEntity {
+	}
+}

--- a/Core/src/main/java/com/github/sef24sp4/core/game/GraphicsOverlayEntityManager.java
+++ b/Core/src/main/java/com/github/sef24sp4/core/game/GraphicsOverlayEntityManager.java
@@ -7,7 +7,7 @@ import com.github.sef24sp4.core.interfaces.EntityToGraphicsMapper;
 public class GraphicsOverlayEntityManager extends EntityManager {
 	private final EntityToGraphicsMapper<IEntity, ?> graphicsMapping;
 
-	GraphicsOverlayEntityManager(EntityToGraphicsMapper<IEntity, ?> graphicsMapping) {
+	GraphicsOverlayEntityManager(final EntityToGraphicsMapper<IEntity, ?> graphicsMapping) {
 		this.graphicsMapping = graphicsMapping;
 	}
 
@@ -19,13 +19,13 @@ public class GraphicsOverlayEntityManager extends EntityManager {
 	}
 
 	@Override
-	public boolean addEntity(IEntity entity) {
+	public boolean addEntity(final IEntity entity) {
 		this.graphicsMapping.add(entity);
 		return super.addEntity(entity);
 	}
 
 	@Override
-	public boolean removeEntity(IEntity entity) {
+	public boolean removeEntity(final IEntity entity) {
 		this.graphicsMapping.remove(entity);
 		return super.removeEntity(entity);
 	}


### PR DESCRIPTION
> [!WARNING]
> Interface changes to `IEntityManager`

# What has changed
- `IEntityManager` now works with [`Collection`](https://docs.oracle.com/javase/8/docs/api/java/util/Collection.html) instead of `List` interface. 
   For the most part will this not change much in functionality. 
- `EntityManager` now uses [`HashSet`](https://docs.oracle.com/javase/8/docs/api/java/util/HashSet.html). This means that no duplicate entities should be allowed. (Closes #78).
- `.getAllEntities()` and the other getters now returns [readonly Collection](https://docs.oracle.com/javase/8/docs/api/java/util/Collections.html#unmodifiableCollection-java.util.Collection-) of the entities. 

# What else has been done
- Added JavaDoc to `IEntityManager`
- Added Unit tests for `EntityManager`

# What is missing
Nothing it is perfect*
**maybe*
