### PR TITLE
Use more specific return types for vector methods

### DIFF
--- a/Common/src/main/java/com/github/sef24sp4/common/vector/Coordinates.java
+++ b/Common/src/main/java/com/github/sef24sp4/common/vector/Coordinates.java
@@ -17,10 +17,10 @@ public class Coordinates extends BasicVector implements Cloneable {
 	 * @param coordinates The other coordinates. Maybe any type of vector.
 	 * @return A vector between the two coordinates.
 	 */
-	public IVector getVectorTo(final IVector coordinates) {
+	public BasicVector getVectorTo(final IVector coordinates) {
 		final double deltaX = coordinates.getX() - this.getX();
 		final double deltaY = coordinates.getY() - this.getY();
-		return new Coordinates(deltaX, deltaY);
+		return new BasicVector(deltaX, deltaY);
 	}
 
 	/**

--- a/Common/src/main/java/com/github/sef24sp4/common/vector/IVector.java
+++ b/Common/src/main/java/com/github/sef24sp4/common/vector/IVector.java
@@ -61,7 +61,7 @@ public interface IVector {
 	 * Unless current vector is a zero vector, then a new zero vector is returned.
 	 * @see <a href="https://stackoverflow.com/a/722087">Stackoverflow: How do you normalize a zero vector</a>
 	 */
-	public default IVector getNormalizedVector() {
+	public default BasicVector getNormalizedVector() {
 		final double norm = this.getNorm();
 		if (norm == 0) return new BasicVector();
 		return new BasicVector(this.getX() / norm, this.getY() / norm);
@@ -74,7 +74,7 @@ public interface IVector {
 	 *
 	 * @return The negative vector.
 	 */
-	public default IVector getNegative() {
+	public default BasicVector getNegative() {
 		return new BasicVector(-this.getX(), -this.getY());
 	}
 }


### PR DESCRIPTION
This is to avoid forced down casts, which is a bad practice. 
It is however much safer and automatic to upcast.