### PR TITLE
Add additional methods to MapNode

### DIFF
--- a/CommonAI/src/main/java/com/github/sef24sp4/common/ai/map/MapNode.java
+++ b/CommonAI/src/main/java/com/github/sef24sp4/common/ai/map/MapNode.java
@@ -34,13 +34,28 @@ public interface MapNode {
 	/**
 	 * Calculate safe {@link IVector coordinates} for {@link ICollidableEntity entity}
 	 * given that the entity needs to traverse in a linear fashion from a start {@link IVector position}.
+	 * <p/>
+	 * If the returned {@link Optional} has some {@link IVector coordinates}, then it is guaranteed that
+	 * {@link #containsCoordinates(IVector) currentNode.containsCoordinates(returnedCoordinates) == true}.
 	 *
 	 * @param entity       To calculate safe coordinates for entity.
 	 * @param fromPosition The position from where the entity needs to traverse from in a linear fashion.
 	 * @return An {@link Optional} with an {@link IVector} describing safe coordinates for the {@code entity} if such coordinates exists.
 	 * Otherwise, returns an {@link Optional#empty empty Optional}.
+	 * @throws NotAdjacentNodeException if the implementation requires the node to be adjacent to the current node.
+	 *                                  It is implementation specific when a node is considered adjacent.
+	 * @see #isNodeAdjacent(MapNode)
 	 */
-	public Optional<IVector> getSafeCoordinatesForEntity(final ICollidableEntity entity, final IVector fromPosition);
+	public Optional<IVector> getSafeCoordinatesForEntity(final ICollidableEntity entity, final IVector fromPosition) throws NotAdjacentNodeException;
+
+	/**
+	 * Check if {@link MapNode node} is considered to be adjacent to the current node by the implementation.
+	 *
+	 * @param node The {@link MapNode} to check for.
+	 * @return {@code true} if the {@code node} is considered to be adjacent to the current node.
+	 * {@code false} otherwise.
+	 */
+	public boolean isNodeAdjacent(final MapNode node);
 
 	/**
 	 * Calculates heuristics given a {@link MapNode target node}.

--- a/CommonAI/src/main/java/com/github/sef24sp4/common/ai/map/NotAdjacentNodeException.java
+++ b/CommonAI/src/main/java/com/github/sef24sp4/common/ai/map/NotAdjacentNodeException.java
@@ -1,0 +1,32 @@
+package com.github.sef24sp4.common.ai.map;
+
+/**
+ * May be thrown by
+ * {@link MapNode#getSafeCoordinatesForEntity(com.github.sef24sp4.common.entities.ICollidableEntity, com.github.sef24sp4.common.vector.IVector)}
+ * if required by the implementation.
+ */
+public class NotAdjacentNodeException extends Exception {
+	public NotAdjacentNodeException(final String message) {
+		super(message);
+	}
+
+	public NotAdjacentNodeException() {
+		this("Not adjacent node");
+	}
+
+	/**
+	 * Creates an exception with a default message given the two arguments.
+	 * <p/>
+	 * The default message has the following format. "<i>node.toString() is not Adjacent to the current node (currentNode.toString())</i>"
+	 *
+	 * @param currentNode The current node.
+	 * @param node        The node which was not adjacent to {@code currentNode}.
+	 */
+	public NotAdjacentNodeException(final MapNode currentNode, final MapNode node) {
+		this(String.format("%s is not Adjacent to the current node (%s)", node, currentNode));
+	}
+
+	public NotAdjacentNodeException(final String message, final Throwable cause) {
+		super(message, cause);
+	}
+}


### PR DESCRIPTION
These methods allows to get more information about a node and related
nodes.

# What has been changed
> [!WARN]
> Interface change `mapNode.getSafeCoordinates()` may throw checked `NotAdjacentNodeException`.
> Please read relevant JavaDoc.

- Improved JavaDoc


# What has been added
- `MapNode.isNodeAdjacent()` method has been added.
- `NotAdjacentNodeException` exception class has been added.
