### PR TITLE
Defined MapProvider interface

### DIFF
--- a/CommonAI/src/main/java/com/github/sef24sp4/common/ai/map/MapProvider.java
+++ b/CommonAI/src/main/java/com/github/sef24sp4/common/ai/map/MapProvider.java
@@ -1,0 +1,35 @@
+package com.github.sef24sp4.common.ai.map;
+
+import com.github.sef24sp4.common.interfaces.IGameSettings;
+
+import java.util.Optional;
+import java.util.ServiceLoader;
+
+/**
+ * A factory for creating and fetching a {@link Map} instance.
+ */
+public interface MapProvider {
+	/**
+	 * Load any available {@link MapProvider} using {@link ServiceLoader#load(Class)} and fetch the provided {@link Map}.
+	 *
+	 * @param gameSettings The {@link IGameSettings} of the game.
+	 * @return An {@link Optional} with the fetched {@link Map} if a {@link MapProvider} was found.
+	 * Otherwise, an {@link Optional#empty() empty Optional} is returned.
+	 * @see #fetch(IGameSettings)
+	 */
+	public static Optional<Map> load(final IGameSettings gameSettings) {
+		return ServiceLoader.load(MapProvider.class).findFirst().map(s -> s.fetch(gameSettings));
+	}
+
+	/**
+	 * Fetch a {@link Map} from the current provider.
+	 * <p/>
+	 * It is generally recommended to use the static {@link #load(IGameSettings)} method,
+	 * when wanting to fetch a {@link Map} from a provider.
+	 *
+	 * @param gameSettings The {@link IGameSettings} of the game.
+	 * @return The {@link Map} instance of the provider.
+	 * @see #load(IGameSettings)
+	 */
+	public Map fetch(final IGameSettings gameSettings);
+}

--- a/CommonAI/src/main/java/module-info.java
+++ b/CommonAI/src/main/java/module-info.java
@@ -1,4 +1,5 @@
 module CommonAI {
+	uses com.github.sef24sp4.common.ai.map.MapProvider;
 	requires Common;
 	exports com.github.sef24sp4.common.ai;
 	exports com.github.sef24sp4.common.ai.map;


### PR DESCRIPTION
# What has been done
- Define `MapProvider` interface which allows to get a `Map` instance from a given provider. 
- Add `MapProvider.load(IGameSettings)` which automatically locates a `MapProvider` and fetches the `Map` instance. 